### PR TITLE
noetic-devel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES geolib
   CATKIN_DEPENDS cv_bridge roscpp shape_msgs tf
-  DEPENDS OpenCV #ASSIMP
+  DEPENDS OpenCV ASSIMP
 )
 
 ###########
@@ -26,7 +26,7 @@ catkin_package(
 
 include_directories(
   include
-#  ${ASSIMP_INCLUDE_DIRS} Broxen, fixed in https://github.com/assimp/assimp/pull/2161, released from 5.0.1
+  ${ASSIMP_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
   ${OpenCV_INCLUDE_DIRS}
 )


### PR DESCRIPTION
This breaks with any distro without assimp 5.0.1

EMC also uses this repo, so merging this drops support for any ubuntu version before 20.04. So this shouldn't be merged before the course has finished this year.