### PR TITLE
Fix LRF behaviour

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,4 +105,7 @@ add_executable(test_matrix test/test_matrix.cpp)
 if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(test_intersect test/test_intersect.cpp)
   target_link_libraries(test_intersect geolib)
+
+  catkin_add_gtest(test_lrf test/test_lrf.cpp)
+  target_link_libraries(test_lrf geolib)
 endif()

--- a/include/geolib/math_types.h
+++ b/include/geolib/math_types.h
@@ -51,6 +51,9 @@ public:
     /// returns dot product
     T dot(const Vec2T& v) const { return x * v.x + y * v.y; }
 
+    /// returns cross product
+    T cross(const Vec2T& v) const { return x * v.y - y * v.x; }
+
     /// returns addition of this and v
     Vec2T operator+(const Vec2T& v) const {  return Vec2T(x + v.x, y + v.y); }
 

--- a/include/geolib/sensors/LaserRangeFinder.h
+++ b/include/geolib/sensors/LaserRangeFinder.h
@@ -92,8 +92,19 @@ public:
 
     bool rangesToPoints(const std::vector<double>& ranges, std::vector<geo::Vector3>& points) const;
 
+    /**
+     * @brief Get the index of the first beam with a higher angle than this beam
+     * @param angle radial angle of the beam
+     * @return Index of the beam, which bounded to be the number of beams [0, N_BEAMS]
+     */
     uint getAngleUpperIndex(double angle) const;
 
+    /**
+     * @overload uint getAngleUpperIndex(double x, double y) const
+     * @param x x-coordinate
+     * @param y y-coordinate
+     * @return Index of the beam, which bounded to be the number of beams [0, N_BEAMS]
+     */
     uint getAngleUpperIndex(double x, double y) const;
 
     static geo::Vector3 polarTo2D(double angle, double range);

--- a/include/geolib/sensors/LaserRangeFinder.h
+++ b/include/geolib/sensors/LaserRangeFinder.h
@@ -71,6 +71,11 @@ public:
 
     inline double getAngleMax() const { return a_max_; }
 
+    /**
+     * @brief Angle increment between two beams
+     *
+     * \f$ \frac{angle_{max} - angle_{min}}{N_{beams} - 1}\f$
+     */
     double getAngleIncrement() const;
 
     inline const std::vector<double>& getAngles() const { return angles_; }

--- a/include/geolib/sensors/LaserRangeFinder.h
+++ b/include/geolib/sensors/LaserRangeFinder.h
@@ -40,10 +40,10 @@ public:
 
         virtual void renderLine(const Vec2& p1, const Vec2& p2);
 
-        virtual void renderPoint(int index, float depth);
+        virtual void renderPoint(uint index, float depth);
 
-        int min_i;
-        int max_i;
+        uint min_i;
+        uint max_i;
 
         std::vector<double>& ranges;
 
@@ -65,7 +65,7 @@ public:
 
     inline void setRangeLimits(double min, double max) { range_min_ = min; range_max_ = max; }
 
-    void setNumBeams(int n);
+    void setNumBeams(uint n);
 
     inline double getAngleMin() const { return a_min_; }
 
@@ -84,17 +84,17 @@ public:
 
     inline double getRangeMax() const { return range_max_; }
 
-    inline int getNumBeams() const { return num_beams_; }
+    inline uint getNumBeams() const { return num_beams_; }
 
-    geo::Vector3 rangeToPoint(double range, int i) const;
+    geo::Vector3 rangeToPoint(double range, uint i) const;
 
-    const geo::Vector3 getRayDirection(int i) const;
+    const geo::Vector3 getRayDirection(uint i) const;
 
     bool rangesToPoints(const std::vector<double>& ranges, std::vector<geo::Vector3>& points) const;
 
-    int getAngleUpperIndex(double angle) const;
+    uint getAngleUpperIndex(double angle) const;
 
-    int getAngleUpperIndex(double x, double y) const;
+    uint getAngleUpperIndex(double x, double y) const;
 
     static geo::Vector3 polarTo2D(double angle, double range);
 
@@ -108,7 +108,7 @@ protected:
 
     double range_min_, range_max_;
 
-    int num_beams_;
+    uint num_beams_;
 
     std::vector<double> angles_;
 
@@ -117,7 +117,7 @@ protected:
     double angle_incr_;
 
     // Number of beams in a half circle
-    int i_half_circle_;
+    uint i_half_circle_;
 
     void calculateRays();
 

--- a/include/geolib/sensors/LaserRangeFinder.h
+++ b/include/geolib/sensors/LaserRangeFinder.h
@@ -116,6 +116,7 @@ protected:
 
     std::vector<geo::Vector3> ray_dirs_;
 
+    double angle_incr_;
     double slope_factor_;
     std::vector<int> slope_to_index_[8];
     int i_half_circle_;

--- a/include/geolib/sensors/LaserRangeFinder.h
+++ b/include/geolib/sensors/LaserRangeFinder.h
@@ -115,8 +115,8 @@ protected:
     std::vector<geo::Vector3> ray_dirs_;
 
     double angle_incr_;
-    double slope_factor_;
-    std::vector<int> slope_to_index_[8];
+
+    // Number of beams in a half circle
     int i_half_circle_;
 
     void calculateRays();

--- a/include/geolib/sensors/LaserRangeFinder.h
+++ b/include/geolib/sensors/LaserRangeFinder.h
@@ -100,8 +100,6 @@ public:
 
     static geo::Vector3 polarTo3D(const geo::Pose3D& laser_pose, double angle, double range);
 
-    static double getAngle(double x, double y);
-
     inline const std::vector<geo::Vector3>& rayDirections() const { return ray_dirs_; }
 
 protected:

--- a/include/geolib/sensors/LaserRangeFinder.h
+++ b/include/geolib/sensors/LaserRangeFinder.h
@@ -47,7 +47,7 @@ public:
 
         std::vector<double>& ranges;
 
-        const LaserRangeFinder* lrf_;
+        const geo::LaserRangeFinder* lrf_;
 
     };
 
@@ -55,9 +55,9 @@ public:
 
     virtual ~LaserRangeFinder();
 
-    void render(const LaserRangeFinder::RenderOptions& options, LaserRangeFinder::RenderResult& res) const;
+    void render(const geo::LaserRangeFinder::RenderOptions& options, geo::LaserRangeFinder::RenderResult& res) const;
 
-    RenderResult render(const Shape& shape, const Pose3D& cam_pose, const Pose3D& obj_pose, std::vector<double>& ranges) const;
+    RenderResult render(const geo::Shape& shape, const geo::Pose3D& cam_pose, const geo::Pose3D& obj_pose, std::vector<double>& ranges) const;
 
     void renderLine(const geo::Vec2& p1, const geo::Vec2& p2, std::vector<double>& ranges) const;
 
@@ -97,7 +97,7 @@ public:
 
     static double getAngle(double x, double y);
 
-    inline const std::vector<Vector3>& rayDirections() const { return ray_dirs_; }
+    inline const std::vector<geo::Vector3>& rayDirections() const { return ray_dirs_; }
 
 protected:
 

--- a/src/sensors/LaserRangeFinder.cpp
+++ b/src/sensors/LaserRangeFinder.cpp
@@ -468,9 +468,10 @@ double LaserRangeFinder::getAngle(double x, double y) {
         }
     }
 
+    // Wrap to (-pi, pi]
     if (a > M_PI) {
         a -= 2 * M_PI ;
-    } else if (a < -M_PI) {
+    } else if (a <= -M_PI) {
         a += 2 * M_PI;
     }
 

--- a/src/sensors/LaserRangeFinder.cpp
+++ b/src/sensors/LaserRangeFinder.cpp
@@ -325,8 +325,7 @@ int LaserRangeFinder::getAngleUpperIndex(double angle) const {
     return std::min(num_beams_, std::max(0, i));
 }
 
-int LaserRangeFinder::getAngleUpperIndex(double x, double y) const
-{
+int LaserRangeFinder::getAngleUpperIndex(double x, double y) const {
     // Calculate the ray index corresponding to the cartesian point (x, y)
     return getAngleUpperIndex(atan2(y, x));
 }

--- a/src/sensors/LaserRangeFinder.cpp
+++ b/src/sensors/LaserRangeFinder.cpp
@@ -50,12 +50,12 @@ void LaserRangeFinder::RenderResult::renderLine(const Vec2& p1, const Vec2& p2)
     }
 
     // Get the angle / beam indices based on the slope
-    int i_p1 = lrf_->getAngleUpperIndex(p1.x, p1.y);
-    int i_p2 = lrf_->getAngleUpperIndex(p2.x, p2.y);
+    uint i_p1 = lrf_->getAngleUpperIndex(p1.x, p1.y);
+    uint i_p2 = lrf_->getAngleUpperIndex(p2.x, p2.y);
 
     // Get the minimum and maximum
-    int i_min = std::min(i_p1, i_p2);
-    int i_max = std::max(i_p1, i_p2);
+    uint i_min = std::min<uint>(i_p1, i_p2);
+    uint i_max = std::max<uint>(i_p1, i_p2);
 
     // We need to differentiate between two cases:
     // - from min to max is less than half a circle
@@ -63,7 +63,7 @@ void LaserRangeFinder::RenderResult::renderLine(const Vec2& p1, const Vec2& p2)
 
     // In the latter case, we may need to render two parts
 
-    int i_min1, i_max1, i_min2, i_max2;
+    uint i_min1, i_max1, i_min2, i_max2;
     if (i_max - i_min < lrf_->i_half_circle_)
     {
         // Back-face culling: if the normal is pointing outwards, ommit this line
@@ -82,8 +82,8 @@ void LaserRangeFinder::RenderResult::renderLine(const Vec2& p1, const Vec2& p2)
         i_min2 = 0;
         i_max2 = 0;
 
-        min_i = std::min(min_i, (int)i_min);
-        max_i = std::max(max_i, (int)i_max);
+        min_i = std::min(min_i, i_min);
+        max_i = std::max(max_i, i_max);
     }
     else
     {
@@ -110,7 +110,7 @@ void LaserRangeFinder::RenderResult::renderLine(const Vec2& p1, const Vec2& p2)
     // of each beam with the line
 
     // Draw part 1
-    for(int i = i_min1; i < i_max1; ++i)
+    for(uint i = i_min1; i < i_max1; ++i)
     {
         const Vector3& r = lrf_->ray_dirs_[i];
         double d = (p1.x * s.y - p1.y * s.x) / (r.x * s.y - r.y * s.x);
@@ -119,7 +119,7 @@ void LaserRangeFinder::RenderResult::renderLine(const Vec2& p1, const Vec2& p2)
     }
 
     // Draw part 2
-    for(int i = i_min2; i < i_max2; ++i)
+    for(uint i = i_min2; i < i_max2; ++i)
     {
         const Vector3& r = lrf_->ray_dirs_[i];
         double d = (p1.x * s.y - p1.y * s.x) / (r.x * s.y - r.y * s.x);
@@ -130,7 +130,7 @@ void LaserRangeFinder::RenderResult::renderLine(const Vec2& p1, const Vec2& p2)
 
 // ----------------------------------------------------------------------------------------------------
 
-void LaserRangeFinder::RenderResult::renderPoint(int i, float d)
+void LaserRangeFinder::RenderResult::renderPoint(uint i, float d)
 {
     if (ranges[i] == 0 || d < ranges[i]) {
         ranges[i] = d;
@@ -174,7 +174,7 @@ void LaserRangeFinder::render(const LaserRangeFinder::RenderOptions& opt, LaserR
     std::vector<double> zs_t(points.size());
     Vector3 Rz = pose.getBasis().getRow(2);
     double z_offset = pose.getOrigin().getZ();
-    for(unsigned int i = 0; i < points.size(); ++i)
+    for(uint i = 0; i < points.size(); ++i)
         zs_t[i] = Rz.dot(points[i]) + z_offset;
 
     Vector3 Rx = pose.getBasis().getRow(0);
@@ -290,7 +290,7 @@ void LaserRangeFinder::setAngleLimits(double min, double max) {
     }
 }
 
-void LaserRangeFinder::setNumBeams(int num_beams) {
+void LaserRangeFinder::setNumBeams(uint num_beams) {
     num_beams_ = num_beams;
     if (num_beams > 0 && a_max_ - a_min_ > 0) {
         calculateRays();
@@ -300,14 +300,14 @@ void LaserRangeFinder::setNumBeams(int num_beams) {
 void LaserRangeFinder::calculateRays() {
     ray_dirs_.clear();
     angles_.clear();
-    angle_incr_ = (a_max_ - a_min_) / std::max(num_beams_ - 1, 1);
+    angle_incr_ = (a_max_ - a_min_) / std::max<uint>(num_beams_ - 1, 1);
 
     ray_dirs_.resize(num_beams_);
     angles_.resize(num_beams_);
 
     // Pre-calculate the unit direction vectors of all the rays
     double a = a_min_;
-    for(int i = 0; i < num_beams_; ++i) {
+    for(uint i = 0; i < num_beams_; ++i) {
         ray_dirs_[i] = polarTo2D(a, 1);
         angles_[i] = a;
         a += angle_incr_;
@@ -320,12 +320,12 @@ double LaserRangeFinder::getAngleIncrement() const {
     return angle_incr_;
 }
 
-int LaserRangeFinder::getAngleUpperIndex(double angle) const {
+uint LaserRangeFinder::getAngleUpperIndex(double angle) const {
     int i = (angle - a_min_) / angle_incr_ + 1;
-    return std::min(num_beams_, std::max(0, i));
+    return std::min<uint>(num_beams_, std::max<int>(0, i));
 }
 
-int LaserRangeFinder::getAngleUpperIndex(double x, double y) const {
+uint LaserRangeFinder::getAngleUpperIndex(double x, double y) const {
     // Calculate the ray index corresponding to the cartesian point (x, y)
     return getAngleUpperIndex(atan2(y, x));
 }
@@ -336,11 +336,11 @@ int LaserRangeFinder::getAngleUpperIndex(double x, double y) const {
 //
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
-geo::Vector3 LaserRangeFinder::rangeToPoint(double range, int i) const {
+geo::Vector3 LaserRangeFinder::rangeToPoint(double range, uint i) const {
     return ray_dirs_[i] * range;
 }
 
-const geo::Vector3 LaserRangeFinder::getRayDirection(int i) const {
+const geo::Vector3 LaserRangeFinder::getRayDirection(uint i) const {
     return ray_dirs_[i];
 }
 
@@ -349,7 +349,7 @@ bool LaserRangeFinder::rangesToPoints(const std::vector<double>& ranges, std::ve
         return false;
     }
     points.resize(ray_dirs_.size());
-    for(unsigned int i = 0; i < ray_dirs_.size(); ++i) {
+    for(uint i = 0; i < ray_dirs_.size(); ++i) {
         points[i] = ray_dirs_[i] * ranges[i];
     }
     return true;

--- a/src/sensors/LaserRangeFinder.cpp
+++ b/src/sensors/LaserRangeFinder.cpp
@@ -3,7 +3,7 @@
 
 namespace geo {
 
-LaserRangeFinder::LaserRangeFinder() : a_min_(0), a_max_(0), range_min_(0), range_max_(0), num_beams_(0) {
+LaserRangeFinder::LaserRangeFinder() : a_min_(0), a_max_(0), range_min_(0), range_max_(0), num_beams_(0), angle_incr_(0) {
 }
 
 LaserRangeFinder::~LaserRangeFinder() {
@@ -298,17 +298,17 @@ void LaserRangeFinder::setNumBeams(int num_beams) {
 void LaserRangeFinder::calculateRays() {
     ray_dirs_.clear();
     angles_.clear();
+    angle_incr_ = (a_max_ - a_min_) / std::max(num_beams_ - 1, 1);
 
     ray_dirs_.resize(num_beams_);
     angles_.resize(num_beams_);
 
     // Pre-calculate the unit direction vectors of all the rays
-    double a_incr = getAngleIncrement();
     double a = a_min_;
     for(int i = 0; i < num_beams_; ++i) {
         ray_dirs_[i] = polarTo2D(a, 1);
         angles_[i] = a;
-        a += a_incr;
+        a += angle_incr_;
     }
 
     // Create a look-up table which translates slope to ray index. This way,
@@ -387,11 +387,11 @@ void LaserRangeFinder::calculateRays() {
         }
     }
 
-    i_half_circle_ = M_PI / getAngleIncrement();
+    i_half_circle_ = M_PI / angle_incr_;
 }
 
 double LaserRangeFinder::getAngleIncrement() const {
-    return (a_max_ - a_min_) / std::max(num_beams_ - 1, 1);
+    return angle_incr_;
 }
 
 int LaserRangeFinder::getAngleUpperIndex(double angle) const {

--- a/src/sensors/LaserRangeFinder.cpp
+++ b/src/sensors/LaserRangeFinder.cpp
@@ -299,13 +299,15 @@ void LaserRangeFinder::calculateRays() {
     ray_dirs_.clear();
     angles_.clear();
 
+    ray_dirs_.resize(num_beams_);
+    angles_.resize(num_beams_);
+
     // Pre-calculate the unit direction vectors of all the rays
     double a_incr = getAngleIncrement();
     double a = a_min_;
     for(int i = 0; i < num_beams_; ++i) {
-        Vector3 dir = polarTo2D(a, 1);
-        ray_dirs_.push_back(dir);
-        angles_.push_back(a);
+        ray_dirs_[i] = polarTo2D(a, 1);
+        angles_[i] = a;
         a += a_incr;
     }
 
@@ -315,7 +317,7 @@ void LaserRangeFinder::calculateRays() {
 
     // Determine the needed resolution of the look-up table (TODO: make less ad-hoc)
     slope_factor_ = 1 / tan(getAngleIncrement()) * 10;
-    int N = (int)slope_factor_ + 1;
+    int N = static_cast<int>(slope_factor_) + 1;
 
     for(unsigned int i = 0; i < 8; ++i)
         slope_to_index_[i].resize(N);
@@ -333,7 +335,7 @@ void LaserRangeFinder::calculateRays() {
         for(int k = 0; k < N; ++k)
         {
             // Calculate the slope corresponding to this table entry
-            double slope = (double)k / slope_factor_;
+            double slope = static_cast<double>(k) / slope_factor_;
 
             // Calculate a virtual (x, y) cartesian point which corresponds to this table entry
             // based on the slope. Determine the part of the unit circle in which (x, y) lies

--- a/src/sensors/LaserRangeFinder.cpp
+++ b/src/sensors/LaserRangeFinder.cpp
@@ -455,27 +455,4 @@ geo::Vector3 LaserRangeFinder::polarTo3D(const geo::Pose3D& laser_pose, double a
     return laser_pose.getBasis() * polarTo2D(angle, range);
 }
 
-double LaserRangeFinder::getAngle(double x, double y) {
-    double a = atan(y / x);
-//    double v = y / x;
-//    double a = M_PI_4*v - v*(fabs(v) - 1)*(0.2447 + 0.0663*fabs(v));
-
-    if (x < 0) {
-        if (y < 0) {
-            a = -M_PI + a;
-        } else {
-            a = M_PI + a;
-        }
-    }
-
-    // Wrap to (-pi, pi]
-    if (a > M_PI) {
-        a -= 2 * M_PI ;
-    } else if (a <= -M_PI) {
-        a += 2 * M_PI;
-    }
-
-    return a;
-}
-
 }

--- a/src/sensors/LaserRangeFinder.cpp
+++ b/src/sensors/LaserRangeFinder.cpp
@@ -104,7 +104,7 @@ void LaserRangeFinder::RenderResult::renderLine(const Vec2& p1, const Vec2& p2)
 
     // d = (q1 - ray_start) x s / (r x s)
     //   = (q1 x s) / (r x s)
-    Vec2 s = p2 - p1;
+    Vec2& s = diff;
 
     // For all beam regions found above (1 or 2 regions), calculate the intersection
     // of each beam with the line
@@ -112,8 +112,8 @@ void LaserRangeFinder::RenderResult::renderLine(const Vec2& p1, const Vec2& p2)
     // Draw part 1
     for(uint i = i_min1; i < i_max1; ++i)
     {
-        const Vector3& r = lrf_->ray_dirs_[i];
-        double d = (p1.x * s.y - p1.y * s.x) / (r.x * s.y - r.y * s.x);
+        const geo::Vec2& r = lrf_->ray_dirs_[i].projectTo2d();
+        double d = p1.cross(s) / r.cross(s);
         if (d > 0)
             renderPoint(i, d);
     }
@@ -121,8 +121,8 @@ void LaserRangeFinder::RenderResult::renderLine(const Vec2& p1, const Vec2& p2)
     // Draw part 2
     for(uint i = i_min2; i < i_max2; ++i)
     {
-        const Vector3& r = lrf_->ray_dirs_[i];
-        double d = (p1.x * s.y - p1.y * s.x) / (r.x * s.y - r.y * s.x);
+        const geo::Vec2& r = lrf_->ray_dirs_[i].projectTo2d();
+        double d = p1.cross(s) / r.cross(s);
         if (d > 0)
             renderPoint(i, d);
     }

--- a/src/sensors/LaserRangeFinder.cpp
+++ b/src/sensors/LaserRangeFinder.cpp
@@ -327,6 +327,16 @@ void LaserRangeFinder::calculateRays() {
     // x < 0
     // y < 0
 
+    //    \ 4 | 6 /
+    //     \  |  /
+    //   5  \ | /  7
+    //       \|/
+    // ---------------
+    //       /|\
+    //   1  / | \  3
+    //     /  |  \
+    //    / 0 | 2 \
+
     // This way we can always calculate a slope between 0 and 1 (by dividing the
     // smallest coordinate by the biggest).
     for(int j = 0; j < 8; ++j)

--- a/test/test_lrf.cpp
+++ b/test/test_lrf.cpp
@@ -6,7 +6,7 @@
 
 double ANGLE_MIN = -M_PI_2;
 double ANGLE_MAX = M_PI_2;
-uint N_BEAMS = 10;
+uint N_BEAMS = 9;
 
 TEST(TestLRF, getAngleUpperIndexAngle)
 {
@@ -14,6 +14,9 @@ TEST(TestLRF, getAngleUpperIndexAngle)
     lrf.setAngleLimits(ANGLE_MIN, ANGLE_MAX);
     lrf.setNumBeams(N_BEAMS);
     ASSERT_EQ(lrf.getAngleUpperIndex(1.5*ANGLE_MIN), 0);
+    ASSERT_EQ(lrf.getAngleUpperIndex(ANGLE_MIN), 1);
+    ASSERT_EQ(lrf.getAngleUpperIndex(0.5*ANGLE_MIN + 0.5*ANGLE_MAX), std::floor(0.5*N_BEAMS-0.5)+1);
+    ASSERT_EQ(lrf.getAngleUpperIndex(ANGLE_MAX), N_BEAMS);
     ASSERT_EQ(lrf.getAngleUpperIndex(1.5*ANGLE_MAX), N_BEAMS);
 }
 
@@ -23,6 +26,9 @@ TEST(TestLRF, getAngleUpperIndexXY)
     lrf.setAngleLimits(ANGLE_MIN, ANGLE_MAX);
     lrf.setNumBeams(N_BEAMS);
     ASSERT_EQ(lrf.getAngleUpperIndex(cos(1.5*ANGLE_MIN), sin(1.5*ANGLE_MIN)), 0);
+    ASSERT_EQ(lrf.getAngleUpperIndex(cos(ANGLE_MIN), sin(ANGLE_MIN)), 1);
+    ASSERT_EQ(lrf.getAngleUpperIndex(cos(0.5*ANGLE_MIN + 0.5*ANGLE_MAX), sin(0.5*ANGLE_MIN + 0.5*ANGLE_MAX)), std::floor(0.5*N_BEAMS-0.5)+1);
+    ASSERT_EQ(lrf.getAngleUpperIndex(cos(ANGLE_MAX), sin(ANGLE_MAX)), N_BEAMS);
     ASSERT_EQ(lrf.getAngleUpperIndex(cos(1.5*ANGLE_MAX), sin(1.5*ANGLE_MAX)), N_BEAMS);
 }
 

--- a/test/test_lrf.cpp
+++ b/test/test_lrf.cpp
@@ -1,0 +1,33 @@
+#include <gtest/gtest.h>
+
+#include <geolib/sensors/LaserRangeFinder.h>
+
+#include <cmath>
+
+double ANGLE_MIN = -M_PI_2;
+double ANGLE_MAX = M_PI_2;
+uint N_BEAMS = 10;
+
+TEST(TestLRF, getAngleUpperIndexAngle)
+{
+    geo::LaserRangeFinder lrf;
+    lrf.setAngleLimits(ANGLE_MIN, ANGLE_MAX);
+    lrf.setNumBeams(N_BEAMS);
+    ASSERT_EQ(lrf.getAngleUpperIndex(1.5*ANGLE_MIN), 0);
+    ASSERT_EQ(lrf.getAngleUpperIndex(1.5*ANGLE_MAX), N_BEAMS);
+}
+
+TEST(TestLRF, getAngleUpperIndexXY)
+{
+    geo::LaserRangeFinder lrf;
+    lrf.setAngleLimits(ANGLE_MIN, ANGLE_MAX);
+    lrf.setNumBeams(N_BEAMS);
+    ASSERT_EQ(lrf.getAngleUpperIndex(cos(1.5*ANGLE_MIN), sin(1.5*ANGLE_MIN)), 0);
+    ASSERT_EQ(lrf.getAngleUpperIndex(cos(1.5*ANGLE_MAX), sin(1.5*ANGLE_MAX)), N_BEAMS);
+}
+
+int main(int argc, char **argv)
+{
+   testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Most important change is the change in getAngleUpperIndex.

As you can see in the old implementation the beam close to the corner of the object is incorrect. Also the last hit is already outside the object, you can see the coordinates of it(beam 40) in the right lower terminal. The object ends at (1, 1.5).

This is fixed in new implementation. To run this specific situation: `rosrun geolib2 test_geolib_lrf 50 2 1 0 1 2`

Also I dropped al our custom implementation for `atan2`, which works faster than our implementations, see [test/atan2](https://github.com/tue-robotics/geolib2/tree/test/atan2) branch.

Old implementation:
![Screenshot from 2022-04-23 14-18-20](https://user-images.githubusercontent.com/18014833/164895523-85a7ed13-1475-4c0c-821d-e4f646b06a47.png)
New implementation: 
![Screenshot from 2022-04-23 14-18-35](https://user-images.githubusercontent.com/18014833/164895580-0db1c072-067f-471f-9b85-753bc1d3d155.png)